### PR TITLE
area-modal-bug

### DIFF
--- a/src/components/CreateAreaModal/CreateAreaModal.jsx
+++ b/src/components/CreateAreaModal/CreateAreaModal.jsx
@@ -26,7 +26,7 @@ const CreateAreaModal = ({ isOpen, setIsOpen }) => {
 
     if (areaNames.indexOf(areaName) > -1) {
       // same area name as existing one
-      setAlertText(`[ERROR] area name ${areaName} already exists`);
+      setAlertText(`[ERROR] Area Name ${areaName} already exists`);
       setIsAlertSuccess(false);
       closeModal();
       return;

--- a/src/components/EditAreaModal/EditAreaModal.jsx
+++ b/src/components/EditAreaModal/EditAreaModal.jsx
@@ -75,7 +75,10 @@ const EditAreaModal = props => {
               <Form.Control
                 placeholder="Area Name"
                 defaultValue={areaName}
-                onChange={({ target }) => setName(target.value)}
+                onChange={({ target }) => {
+                  setName(target.value);
+                  setNameExists(false);
+                }}
                 className={nameExists ? styles.error : ''}
               />
               {nameExists ? <p className={styles['error-msg']}> {name} already exists </p> : null}

--- a/src/components/EditAreaModal/EditAreaModal.jsx
+++ b/src/components/EditAreaModal/EditAreaModal.jsx
@@ -14,6 +14,7 @@ const EditAreaModal = props => {
   const [state, setState] = useState(areaState);
   const [status, setStatus] = useState(areaActive);
   const [warningOpen, setWarningOpen] = useState(false);
+  const [nameExists, setNameExists] = useState(false);
 
   const reloadPage = () => {
     window.location.reload(true);
@@ -34,8 +35,16 @@ const EditAreaModal = props => {
     });
   };
 
-  const updateArea = () => {
+  const updateArea = async () => {
     // TODO: Add error message if the request fails
+    const areas = await TLPBackend.get('/areas');
+    const areaNames = areas.data.map(area => area.areaName);
+
+    if (areaNames.indexOf(name) > -1) {
+      setNameExists(true);
+      return;
+    }
+
     TLPBackend.put(`/areas/${areaId}`, {
       areaName: name,
       areaState: state,
@@ -67,7 +76,9 @@ const EditAreaModal = props => {
                 placeholder="Area Name"
                 defaultValue={areaName}
                 onChange={({ target }) => setName(target.value)}
+                className={nameExists ? styles.error : ''}
               />
+              {nameExists ? <p className={styles['error-msg']}> {name} already exists </p> : null}
             </Form.Group>
             <Form.Group className="mb-3" controlId="editArea.state">
               <Form.Label>State</Form.Label>

--- a/src/components/EditAreaModal/EditAreaModal.module.css
+++ b/src/components/EditAreaModal/EditAreaModal.module.css
@@ -1,3 +1,13 @@
 .buttons {
   color: var(--text-color-white);
 }
+
+.error {
+  border-color: red;
+}
+
+.error-msg {
+  color: red;
+  padding-top: 2px;
+  font-size: 14px;
+}


### PR DESCRIPTION
On the Edit area modal, the area name an area is changed to must be unique (the backend already checks this). Display an error message that lets the user know if they try to make an area with a name that already exists.
closes #131